### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   auto-merge:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   verify:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
 
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
     needs: [verify]
     if: needs.verify.outputs.new-release-published == 'true'
     name: Release
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 2 GitHub Actions workflow files.

## Validation

- Verified 3 exact runner-label replacements.
- Verified no other staged lines changed.
- `git diff --check` passes.